### PR TITLE
Fix VS compatibility - Suggestions

### DIFF
--- a/GitAutoFetch_Dev16/GitAutoFetch_Dev16.csproj
+++ b/GitAutoFetch_Dev16/GitAutoFetch_Dev16.csproj
@@ -67,10 +67,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.1.32210.191" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.10.31321.278" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.1.4054">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.11.35">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/GitAutoFetch_Dev16/source.extension.vsixmanifest
+++ b/GitAutoFetch_Dev16/source.extension.vsixmanifest
@@ -8,15 +8,9 @@
         <Tags>git, autofetch, git-autofetch, fetch</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0,17.0)">
-            <ProductArchitecture>x86</ProductArchitecture>
-        </InstallationTarget>
-        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[16.0,17.0)">
-            <ProductArchitecture>x86</ProductArchitecture>
-        </InstallationTarget>
-        <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[16.0,17.0)">
-            <ProductArchitecture>x86</ProductArchitecture>
-        </InstallationTarget>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0,17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[16.0,17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[16.0,17.0)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/SharedProject/AssemblyInfo.cs
+++ b/SharedProject/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.5.0")]
-[assembly: AssemblyFileVersion("1.1.5.0")]
+[assembly: AssemblyVersion("1.1.6.0")]
+[assembly: AssemblyFileVersion("1.1.6.0")]

--- a/SharedProject/AutoFetch.cs
+++ b/SharedProject/AutoFetch.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.ComponentModel.Design;
-using System.Threading.Tasks;
+using Task = System.Threading.Tasks.Task;
 
 namespace GitAutoFetch
 {

--- a/SharedProject/GitAutoFetchPackage.cs
+++ b/SharedProject/GitAutoFetchPackage.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
-using System.Threading.Tasks;
+using Task = System.Threading.Tasks.Task;
 
 namespace GitAutoFetch
 {


### PR DESCRIPTION
When I took a copy of the current fix/VSCompatibility branch from @Leprox43 and compiled the VSIX, I unfortunately ran into the same extension launch issues on Visual Studio 2019 Community Edition per https://github.com/ViniciusAlberkovics/VSGitAutoFetch/issues/4:

```
  <entry>
    <record>2898</record>
    <time>2022/03/08 22:37:39.148</time>
    <type>Error</type>
    <source>VisualStudio</source>
    <description>CreateInstance failed for package [GitAutoFetchPackage]Source: &apos;mscorlib&apos; Description: Could not load file or assembly &apos;Microsoft.VisualStudio.Shell.15.0, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a&apos; or one of its dependencies. The system cannot find the file specified.&#x000D;&#x000A;System.IO.FileNotFoundException: Could not load file or assembly &apos;Microsoft.VisualStudio.Shell.15.0, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a&apos; or one of its dependencies. The system cannot find the file specified.&#x000D;&#x000A;File name: &apos;Microsoft.VisualStudio.Shell.15.0, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a&apos;&#x000D;&#x000A;   at System.Reflection.RuntimeAssembly.GetType(RuntimeAssembly assembly, String name, Boolean throwOnError, Boolean ignoreCase, ObjectHandleOnStack type)&#x000D;&#x000A;   at System.Reflection.RuntimeAssembly.GetType(String name, Boolean throwOnError, Boolean ignoreCase)&#x000D;&#x000A;   at System.Activator.CreateInstanceFromInternal(String assemblyFile, String typeName, Boolean ignoreCase, BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture, Object[] activationAttributes, Evidence securityInfo)&#x000D;&#x000A;   at System.AppDomain.CreateInstanceFrom(String assemblyFile, String typeName)&#x000D;&#x000A;&#x000D;&#x000A;WRN: Assembly binding logging is turned OFF.&#x000D;&#x000A;To enable assembly bind failure logging, set the registry value [HKLM\Software\Microsoft\Fusion!EnableLog] (DWORD) to 1.&#x000D;&#x000A;Note: There is some performance penalty associated with assembly bind failure logging.&#x000D;&#x000A;To turn this feature off, remove the registry value [HKLM\Software\Microsoft\Fusion!EnableLog].&#x000D;&#x000A;</description>
    <guid>{A0B3344D-E011-4159-8052-C8EED06BC3AB}</guid>
    <hr>80004005 - E_FAIL</hr>
    <errorinfo></errorinfo>
  </entry>
```

- I've refactored the package reference targets for the Dev16 project to diverge from Dev17 per [MS Docs](https://docs.microsoft.com/en-us/visualstudio/extensibility/migration/target-previous-versions?view=vs-2022).
- I corrected a roslyn ambiguity compilation error for `System.Threading.Tasks.Task`.
- I fixed a vsixmanifest regression, [ProductArchitecture metadata is only compatible with v17.x of build tools](https://developercommunity.visualstudio.com/t/schema-validation-error-after-using-vsix-manifest/1521924).
- Bumped the assembly version which was missed.

This allowed me to compile without error, install the extension successfully in VS19 Community and use the extension as designed.